### PR TITLE
signer: Expose digest algorithm from Signer

### DIFF
--- a/pkg/gcpkms/signer.go
+++ b/pkg/gcpkms/signer.go
@@ -93,8 +93,8 @@ func (s *Signer) Public() crypto.PublicKey {
 	return s.publicKey
 }
 
-// DigestAlg returns the hash algorithm used for computing the digest.
-func (s *Signer) DigestAlg() crypto.Hash {
+// DigestAlgorithm returns the hash algorithm used for computing the digest.
+func (s *Signer) DigestAlgorithm() crypto.Hash {
 	return s.digestAlg
 }
 
@@ -115,16 +115,16 @@ func (s *Signer) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byt
 	ctx := s.context()
 
 	// Make sure the opts and digest length are correct
-	if opts != nil && opts.HashFunc() != s.DigestAlg() {
-		return nil, fmt.Errorf("digest algorithm is %d, want %d", opts.HashFunc(), s.DigestAlg())
+	if opts != nil && opts.HashFunc() != s.digestAlg {
+		return nil, fmt.Errorf("digest algorithm is %d, want %d", opts.HashFunc(), s.digestAlg)
 	}
-	if len(digest) != s.DigestAlg().Size() {
-		return nil, fmt.Errorf("digest length is %d, want %d", len(digest), s.DigestAlg().Size())
+	if len(digest) != s.digestAlg.Size() {
+		return nil, fmt.Errorf("digest length is %d, want %d", len(digest), s.digestAlg.Size())
 	}
 
 	// Set the correct digest based on the key's digest algorithm
 	var dig *kmspb.Digest
-	switch s.DigestAlg() {
+	switch s.digestAlg {
 	case crypto.SHA256:
 		dig = &kmspb.Digest{Digest: &kmspb.Digest_Sha256{Sha256: digest}}
 	case crypto.SHA384:


### PR DESCRIPTION
This change does three things:
  - Exposes a `Signer.DigestAlg()` method indicating which hash algorithm _must_ be used with this key.
    - This is useful when attempting to write code that works with a user-supplied signing key
    - We are careful to only use the [`crypto.Hash`](https://golang.org/pkg/crypto/#Hash) methods that don't require the hash implementation to be linked in.
  - `Signer.Sign()` now checks that the `digest` and `ops` fields are correct
    - This is useful as the [`crypto.Signer` API](https://golang.org/pkg/crypto/#Signer) was initially created to work with private keys that could work with multiple different hash algorithms. However, this model does not apply to KMS keys.
    - Passing in incorrect parameters now fails earlier (without sending an API request) with a better error message.
    - This is similar to what we did for [TPM-based keys](https://github.com/google/go-tpm-tools/blob/4f3f3b508c7f808aec7ddbbe3ca3e1aa8276b0d6/tpm2tools/signer.go#L46-L51) (which have similar restrictions).
  - Fixes #4, so that `RSA_SIGN_PSS_4096_SHA512` works correctly.
    - This was missed in https://github.com/sethvargo/go-gcpkms/commit/a0ed38b9df1f6624c3a6ff9a4d2447d8b7beaeec, as `kmspb.CryptoKeyVersion_RSA_SIGN_PSS_4096_SHA512` was not added to the SHA512 case.

Signed-off-by: Joe Richey <joerichey@google.com>